### PR TITLE
Set dependecies to the lastest versions. Fix 3 failure unit-tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,16 +11,16 @@
 	"author": "Marcos Tischer Vallim <tischer@gmail.com>",
 	"dependencies": {},
 	"devDependencies": {
-		"chai": "^1.9.1",
+		"chai": "^4.0.2",
 		"gulp": "^3.9.1",
 		"gulp-clean": "^0.3.2",
 		"gulp-uglifyjs": "^0.6.2",
-		"karma": "^0.12.17",
+		"karma": "^1.7.0",
 		"karma-chai": "^0.1.0",
-		"karma-mocha": "^0.1.4",
+		"karma-mocha": "^1.3.0",
 		"karma-phantomjs-launcher": "^1.0.4",
 		"karma-verbose-reporter": "^0.0.6",
-		"mocha": "^1.20.1",
+		"mocha": "^3.4.2",
 		"phantomjs-prebuilt": "^2.1.14",
 		"phantomjs2": "^2.2.0"
 	}


### PR DESCRIPTION
This version of Chai doesn't have assert.isBelow method !